### PR TITLE
Update BounceRequest.php

### DIFF
--- a/src/Requests/BounceRequest.php
+++ b/src/Requests/BounceRequest.php
@@ -50,7 +50,7 @@ class BounceRequest extends BaseRequest
         foreach ($recipients as $recipient) {
             $destinations[] = [
                 "email" => $recipient["emailAddress"],
-                "action" => $recipient["action"],
+                "action" => $recipient["action"] ?? null,
                 "options" => array_merge($additional, [
                     "status" => $recipient["status"] ?? null,
                     "diagnostic" => $recipient["diagnosticCode"] ?? null,


### PR DESCRIPTION
Per [Amazon's documentation](https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html), the "action" field is optional for a bounced recipient. This should test if the "action" field exists, and if not, it provides a fallback if the data isn't there.